### PR TITLE
fix issue 5 : improve argument parsing

### DIFF
--- a/bin/ie-gen-mets.rb
+++ b/bin/ie-gen-mets.rb
@@ -17,7 +17,7 @@ UNAVAILABLE_STR = 'UNAVAIL'
 class Part
   attr_reader :mptr, :orderlabel
   def initialize(str)
-    x, @orderlabel = str.split(PART_DELIMITER)
+    x, @orderlabel = str.split(PART_DELIMITER,2)
     @mptr = (x == UNAVAILABLE_STR ? nil : x)
   end
 end

--- a/test/canonical/valid_mets_complex_label.xml
+++ b/test/canonical/valid_mets_complex_label.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version191/mets.xsd" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:mods="http://www.loc.gov/mods/v3" OBJID="6efa1021-7453-4150-8d4a-705899530d8e">
+    <?ie-wip-template version="info:nyu/dl/v1.0/templates/ie/wip/v0.0.1"?>
+    <metsHdr CREATEDATE="2014-03-05T17:17:15Z" LASTMODDATE="2014-03-05T17:17:15Z" RECORDSTATUS="DRAFT">
+        <agent ROLE="DISSEMINATOR" TYPE="ORGANIZATION">
+            <name>New York University Libraries</name>
+	</agent>
+        <agent ROLE="CREATOR" TYPE="INDIVIDUAL">
+            <name>Joseph G. Pawletko</name>
+	</agent>
+        <altRecordID TYPE="NYU-DL-RSTAR">6efa1021-7453-4150-8d4a-705899530d8e</altRecordID>
+    </metsHdr>
+    <dmdSec ID="dmd-00000001">
+        <mdRef LOCTYPE="URL" MDTYPE="OTHER" OTHERMDTYPE="MARCXML" xlink:type="simple" xlink:href="6efa1021-7453-4150-8d4a-705899530d8e_marcxml.xml"/>
+    </dmdSec>
+    <dmdSec ID="dmd-00000002">
+        <mdRef LOCTYPE="URL" MDTYPE="MODS" xlink:type="simple" xlink:href="6efa1021-7453-4150-8d4a-705899530d8e_mods.xml"/>
+    </dmdSec>
+    <amdSec ID="amd-00000001">
+        <rightsMD ID="rmd-00000001">
+            <mdRef LOCTYPE="URL" MDTYPE="METSRIGHTS" xlink:type="simple" xlink:href="6efa1021-7453-4150-8d4a-705899530d8e_metsrights.xml"/>
+	</rightsMD>
+    </amdSec>
+    <structMap ID="smd-00000001" TYPE="INTELLECTUAL_ENTITY">
+        <div>
+            <div TYPE="INTELLECTUAL_ENTITY" ID="s-ie-00000001" DMDID="dmd-00000001 dmd-00000002" ADMID="rmd-00000001" ORDER="1" ORDERLABEL="V1:pt. 2">
+                <mptr LOCTYPE="URL" xlink:type="simple" xlink:href="nyu_aco000177_mets.xml#s-ie-00000001"/>
+	    </div>
+            <div TYPE="INTELLECTUAL_ENTITY" ID="s-ie-00000002" DMDID="dmd-00000001 dmd-00000002" ADMID="rmd-00000001" ORDER="2" ORDERLABEL="V2|strudel">
+                <mptr LOCTYPE="URL" xlink:type="simple" xlink:href="nyu_aco000178_mets.xml#s-ie-00000001"/>
+	    </div>
+            <div TYPE="INTELLECTUAL_ENTITY" ID="s-ie-00000003" DMDID="dmd-00000001 dmd-00000002" ADMID="rmd-00000001" ORDER="3" ORDERLABEL="V3!bar">
+	    </div>
+            <div TYPE="INTELLECTUAL_ENTITY" ID="s-ie-00000004" DMDID="dmd-00000001 dmd-00000002" ADMID="rmd-00000001" ORDER="4" ORDERLABEL="V4&5">
+                <mptr LOCTYPE="URL" xlink:type="simple" xlink:href="nyu_aco000180_mets.xml#s-ie-00000001"/>
+	    </div>
+	</div>
+    </structMap>
+</mets>
+

--- a/test/ie-gen-mets_test.rb
+++ b/test/ie-gen-mets_test.rb
@@ -12,6 +12,13 @@ class TestIeGenMets < MiniTest::Unit::TestCase
   UNAVAIL = 'UNAVAIL:V3'
   PART_4  = 'nyu_aco000180_mets.xml#s-ie-00000001:V4'
 
+  CANONICAL_COMPLEX_LABEL_XML  = 'test/canonical/valid_mets_complex_label.xml'
+  COMPLEX_PART_1  = 'nyu_aco000177_mets.xml#s-ie-00000001:V1:pt. 2'
+  COMPLEX_PART_2  = 'nyu_aco000178_mets.xml#s-ie-00000001:V2|strudel'
+  COMPLEX_UNAVAIL = 'UNAVAIL:V3!bar'
+  COMPLEX_PART_4  = 'nyu_aco000180_mets.xml#s-ie-00000001:V4&5'
+
+
   def test_exit_status_with_valid_ie
     o, e, s = Open3.capture3("#{COMMAND} '6efa1021-7453-4150-8d4a-705899530d8e' #{VALID_IE_PATH} #{PART_1} #{PART_2} #{UNAVAIL} #{PART_4}")
     assert(s == 0, "incorrect exit status")
@@ -45,6 +52,28 @@ class TestIeGenMets < MiniTest::Unit::TestCase
     new_xml, e, s = Open3.capture3("#{COMMAND} '6efa1021-7453-4150-8d4a-705899530d8e' #{VALID_IE_PATH} #{PART_1} #{PART_2} #{UNAVAIL} #{PART_4}")
     assert(s == 0)
     old_xml, e, s = Open3.capture3("cat #{CANONICAL_XML}")
+    new_xml_a = new_xml.split("\n")
+    old_xml_a = old_xml.split("\n")
+
+    new_xml_a.each_index do |i|
+      new = new_xml_a[i].strip
+      old = old_xml_a[i].strip
+
+      # strip date-time stamps b/c canonical will have different timestamp than
+      # current test pass
+      if /metsHdr/.match(new)
+        timestamp_regex = /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z/
+        new.gsub!(timestamp_regex,'')
+        old.gsub!(timestamp_regex,'')
+      end
+      assert(new == old, "xml mismatch: #{new} #{old}")
+    end
+  end
+
+  def test_output_with_valid_ie_with_complex_labels
+    new_xml, e, s = Open3.capture3("#{COMMAND} '6efa1021-7453-4150-8d4a-705899530d8e' '#{VALID_IE_PATH}' '#{COMPLEX_PART_1}' '#{COMPLEX_PART_2}' '#{COMPLEX_UNAVAIL}' '#{COMPLEX_PART_4}'")
+    assert(s == 0, "Error creating xml. #{e}")
+    old_xml, e, s = Open3.capture3("cat #{CANONICAL_COMPLEX_LABEL_XML}")
     new_xml_a = new_xml.split("\n")
     old_xml_a = old_xml.split("\n")
 


### PR DESCRIPTION
changed delimiter parsing:
split only on first occurrence of the colon (':') that delimits the SE ID and the label.
This allows for colons in the label.
